### PR TITLE
[logging] append carriage return to log messages

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -57,17 +57,17 @@ OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const 
     switch (aLogLevel)
     {
     case OT_LOG_LEVEL_CRIT:
-        ESP_LOGE(OT_PLAT_LOG_TAG, "%s", logString);
+        ESP_LOGE(OT_PLAT_LOG_TAG, "%s\r", logString);
         break;
     case OT_LOG_LEVEL_WARN:
-        ESP_LOGW(OT_PLAT_LOG_TAG, "%s", logString);
+        ESP_LOGW(OT_PLAT_LOG_TAG, "%s\r", logString);
         break;
     case OT_LOG_LEVEL_NOTE:
     case OT_LOG_LEVEL_INFO:
-        ESP_LOGI(OT_PLAT_LOG_TAG, "%s", logString);
+        ESP_LOGI(OT_PLAT_LOG_TAG, "%s\r", logString);
         break;
     default:
-        ESP_LOGD(OT_PLAT_LOG_TAG, "%s", logString);
+        ESP_LOGD(OT_PLAT_LOG_TAG, "%s\r", logString);
         break;
     }
     va_end(args);


### PR DESCRIPTION
ESP-IDF log  appends only new line character (`"\n"`) to log messages which causing display issues on platforms that treats `"\r\n"` and `"\n"` differently.

This PR appends carriage return character (`"\r"`) to log message before it is sent to ESP-IDF logging library.

This PR doesn't resolve https://github.com/openthread/ot-esp32/issues/5 but does help.