### PR TITLE
[uart] fix UART line-ending

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -69,8 +69,6 @@ Connect to the ESP32 board from the Linux host:
 make monitor
 ```
 
-_Note: Dependending on your Linux distribution, the new line characters ('\r', '\n') may cause commands display issues. To have good look of the CLI, Connect the ESP32 board with advanced command `picocom -b 115200 /dev/ttyUSB0 --imap lfcrlf` (install `picocom` with `sudo apt-get install picocom`)._
-
 The CLI application is now in interactive mode and waiting for commands, start the OpenThread stack to verify your setup:
 
 ```shell

--- a/src/spinel_hdlc.cpp
+++ b/src/spinel_hdlc.cpp
@@ -316,6 +316,10 @@ void HdlcInterface::InitUart(void)
     // We have a driver now installed so set up the read/write functions to use driver also.
     esp_vfs_dev_uart_use_driver(OT_RADIO_UART_NUM);
 
+    // A workaround to configure line-ending per UART for issue#5.
+    s_ctx[OT_RADIO_UART_NUM]->rx_mode = ESP_LINE_ENDINGS_LF;
+    s_ctx[OT_RADIO_UART_NUM]->tx_mode = ESP_LINE_ENDINGS_LF;
+
     sprintf(uartPath, "/dev/uart/%d", OT_RADIO_UART_NUM);
     mUartFd = open(uartPath, O_RDWR | O_NONBLOCK);
 

--- a/src/uart.c
+++ b/src/uart.c
@@ -95,8 +95,9 @@ void platformCliUartInit()
     // Tell VFS to use UART driver.
     esp_vfs_dev_uart_use_driver(OT_CLI_UART_NUM);
 
-    esp_vfs_dev_uart_set_rx_line_endings(ESP_LINE_ENDINGS_LF);
-    esp_vfs_dev_uart_set_tx_line_endings(ESP_LINE_ENDINGS_LF);
+    // A workaround to configure line-ending per UART for issue#5.
+    s_ctx[OT_CLI_UART_NUM]->rx_mode = ESP_LINE_ENDINGS_CRLF;
+    s_ctx[OT_CLI_UART_NUM]->tx_mode = ESP_LINE_ENDINGS_CRLF;
 
     sprintf(uartPath, "/dev/uart/%d", OT_CLI_UART_NUM);
     sCliUartFd = open(uartPath, O_RDWR | O_NONBLOCK);

--- a/src/uart.c
+++ b/src/uart.c
@@ -95,9 +95,8 @@ void platformCliUartInit()
     // Tell VFS to use UART driver.
     esp_vfs_dev_uart_use_driver(OT_CLI_UART_NUM);
 
-    // A workaround to configure line-ending per UART for issue#5.
-    s_ctx[OT_CLI_UART_NUM]->rx_mode = ESP_LINE_ENDINGS_CRLF;
-    s_ctx[OT_CLI_UART_NUM]->tx_mode = ESP_LINE_ENDINGS_CRLF;
+    esp_vfs_dev_uart_set_rx_line_endings(ESP_LINE_ENDINGS_LF);
+    esp_vfs_dev_uart_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
 
     sprintf(uartPath, "/dev/uart/%d", OT_CLI_UART_NUM);
     sCliUartFd = open(uartPath, O_RDWR | O_NONBLOCK);


### PR DESCRIPTION
This PR disables CRLF conversion in ESP_IDF `vfs/uart` module every time we write radio frame through UART and enables the conversion for CLI UART after finishing writing radio frame. This works because the OpenThread stack is ran in a single task/thread, so there is no CLI operations when we are reading or writing RADIO UART.

addresses issue https://github.com/openthread/ot-esp32/issues/5.