### PR TITLE
[api] add API to break the mainloop

### DIFF
--- a/include/openthread/openthread-esp32.h
+++ b/include/openthread/openthread-esp32.h
@@ -140,6 +140,15 @@ int otSysMainloopPoll(otSysMainloopContext *aMainloop);
 void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMainloop);
 
 /**
+ * This function breaks the mainloop.
+ *
+ * @note This function is designed to break the OpenThread mainloop in case there are
+ *       external events which should be handled immediately.
+ *
+ */
+void otSysMainloopBreak(void);
+
+/**
  * This functions locks the OpenThread API lock.
  *
  * Every OT APIs that takes an otInstance argument

--- a/src/platform-esp32.h
+++ b/src/platform-esp32.h
@@ -101,6 +101,45 @@
 #define OT_UART_RX_BUF_SIZE (UART_FIFO_LEN * 2)
 
 /**
+ * The minimum fd number reserved by the OpenThread platform driver.
+ *
+ * In case the application makes its VFS implementation, the fd range
+ * [OT_RESERVED_FD_MIN, OT_RESERVED_FD_MAX) should not be overlapped.
+ *
+ */
+#define OT_RESERVED_FD_MIN (8)
+
+/**
+ * The maximum fd number reserved by the OpenThread platform driver.
+ *
+ * In case the application makes its VFS implementation, the fd range
+ * [OT_RESERVED_FD_MIN, OT_RESERVED_FD_MAX) should not be overlapped.
+ *
+ */
+#define OT_RESERVED_FD_MAX (9)
+
+/**
+ * The prefix of event device path.
+ *
+ */
+#define OT_EVENT_VFS_PREFIX "/dev/event"
+
+/**
+ * The truncated path of virtual event file.
+ *
+ * This is the virtual event file that used to
+ * wake up a blocked select().
+ *
+ */
+#define OT_EVENT_VFS_SHORT_PATH "/ot"
+
+/**
+ * Full path to the virtual event file.
+ *
+ */
+#define OT_EVENT_VFS_PATH OT_EVENT_VFS_PREFIX OT_EVENT_VFS_SHORT_PATH
+
+/**
  * Milliseconds per Second.
  *
  */
@@ -219,6 +258,41 @@ void platformApiLockInit(void);
  *
  */
 void platformApiLockDeinit(void);
+
+/**
+ * This function initializes VFS driver of event file.
+ *
+ */
+void platformVfsEventInit(void);
+
+/**
+ * This function deinitialize VFS driver of event file.
+ *
+ */
+void platformVfsEventDeinit(void);
+
+/**
+ * This function updates event file events to the mainloop context.
+ *
+ * param[inout] aMainloop  The mainloop context.
+ *
+ */
+void platformVfsEventUpdate(otSysMainloopContext *aMainloop);
+
+/**
+ * This function process event file events.
+ *
+ * @param[in] aInstance  The OpenThread instance.
+ * @param[in] aMainloop  The mainloop context.
+ *
+ */
+void platformVfsEventProcess(otInstance *aInstance, const otSysMainloopContext *aMainloop);
+
+/**
+ * This function activates the event file.
+ *
+ */
+void platformVfsEventActivate(void);
 
 #ifdef __cplusplus
 }

--- a/src/system.c
+++ b/src/system.c
@@ -54,6 +54,7 @@ void otSysInit(int argc, char *argv[])
         gPlatformPseudoResetWasRequested = false;
     }
 
+    platformVfsEventInit();
     platformApiLockInit();
     platformCliUartInit();
     platformRadioInit(/* aResetRadio */ true, /* aRestoreDataSetFromNcp */ false);
@@ -66,6 +67,7 @@ void otSysDeinit(void)
     platformRadioDeinit();
     platformCliUartDeinit();
     platformApiLockDeinit();
+    platformVfsEventDeinit();
 }
 
 bool otSysPseudoResetWasRequested(void)
@@ -86,10 +88,9 @@ void otSysMainloopInit(otSysMainloopContext *aMainloop)
 
 void otSysMainloopUpdate(otInstance *aInstance, otSysMainloopContext *aMainloop)
 {
+    platformVfsEventUpdate(aMainloop);
     platformAlarmUpdate(aMainloop);
-
     platformCliUartUpdate(aMainloop);
-
     platformRadioUpdate(aMainloop);
 
     if (otTaskletsArePending(aInstance))
@@ -107,7 +108,13 @@ int otSysMainloopPoll(otSysMainloopContext *aMainloop)
 
 void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMainloop)
 {
+    platformVfsEventProcess(aInstance, aMainloop);
     platformCliUartProcess(aInstance, aMainloop);
     platformRadioProcess(aInstance, aMainloop);
     platformAlarmProcess(aInstance, aMainloop);
+}
+
+void otSysMainloopBreak(void)
+{
+    platformVfsEventActivate();
 }

--- a/src/vfs_event.c
+++ b/src/vfs_event.c
@@ -1,0 +1,245 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "platform-esp32.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/lock.h>
+#include <sys/select.h>
+
+#include <esp_log.h>
+#include <esp_vfs_dev.h>
+
+#include <openthread/openthread-esp32.h>
+
+#include "error_handling.h"
+
+typedef struct Event {
+    int mFd;
+    bool mIsOpen;
+    bool mCounter;
+    _lock_t mLock;
+} Event;
+
+static Event sEvent = {
+    .mFd = -1,
+    .mIsOpen = false,
+    .mCounter = false,
+    .mLock = 0, // lazy initialized
+};
+
+static SemaphoreHandle_t * sSignalSemaphore = NULL;
+
+static esp_err_t event_start_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, SemaphoreHandle_t *signal_sem)
+{
+    esp_err_t error = ESP_OK;
+
+    (void)writefds;
+    (void)exceptfds;
+
+    _lock_acquire_recursive(&sEvent.mLock);
+
+    VerifyOrExit(sEvent.mIsOpen && nfds > 0 && FD_ISSET(sEvent.mFd, readfds),
+        _lock_release_recursive(&sEvent.mLock));
+
+    _lock_release_recursive(&sEvent.mLock);
+
+    sSignalSemaphore = signal_sem;
+
+    if (sEvent.mCounter > 0) {
+        esp_vfs_select_triggered(sSignalSemaphore);
+    }
+
+exit:
+    return error;
+}
+
+static void event_end_select()
+{
+    sSignalSemaphore = NULL;
+}
+
+static int event_open(const char * path, int flags, int mode)
+{
+    int fd = -1;
+
+    (void)flags;
+    (void)mode;
+
+    _lock_acquire_recursive(&sEvent.mLock);
+
+    VerifyOrExit(strcmp(path, OT_EVENT_VFS_SHORT_PATH) == 0, OT_NOOP);
+    VerifyOrExit(!sEvent.mIsOpen, OT_NOOP);
+
+    sEvent.mFd = OT_RESERVED_FD_MIN;
+    sEvent.mIsOpen = true;
+    fd = sEvent.mFd;
+
+exit:
+    _lock_release_recursive(&sEvent.mLock);
+    return fd;
+}
+
+static ssize_t event_write(int fd, const void * data, size_t size)
+{
+    ssize_t ret = -1;
+
+    (void)data;
+
+    _lock_acquire_recursive(&sEvent.mLock);
+
+    VerifyOrExit(fd == sEvent.mFd && sEvent.mIsOpen, _lock_release_recursive(&sEvent.mLock));
+
+    ++sEvent.mCounter;
+    _lock_release_recursive(&sEvent.mLock);
+
+    if (sSignalSemaphore != NULL)
+    {
+        esp_vfs_select_triggered(sSignalSemaphore);
+    }
+
+    ret = size;
+
+exit:
+    return ret;
+}
+
+static ssize_t event_read(int fd, void* data, size_t size)
+{
+    int ret = -1;
+
+    (void)data;
+    (void)size;
+
+    _lock_acquire_recursive(&sEvent.mLock);
+
+    VerifyOrExit(fd == sEvent.mFd && sEvent.mIsOpen, OT_NOOP);
+
+    ret = sEvent.mCounter;
+    sEvent.mCounter = 0;
+
+exit:
+    _lock_release_recursive(&sEvent.mLock);
+    return ret;
+}
+
+static int event_close(int fd)
+{
+    int ret = -1;
+
+    _lock_acquire_recursive(&sEvent.mLock);
+
+    VerifyOrExit(fd == sEvent.mFd && sEvent.mIsOpen, OT_NOOP);
+
+    sEvent.mIsOpen = false;
+    sEvent.mCounter = 0;
+
+    ret = 0;
+
+exit:
+    _lock_release_recursive(&sEvent.mLock);
+    return ret;
+}
+
+static void event_register(void)
+{
+    esp_vfs_t vfs = {
+        .flags = ESP_VFS_FLAG_DEFAULT,
+        .write = &event_write,
+        .open = &event_open,
+        .fstat = NULL,
+        .close = &event_close,
+        .read = &event_read,
+        .fcntl = NULL,
+        .fsync = NULL,
+        .access = NULL,
+        .start_select = &event_start_select,
+        .end_select = &event_end_select,
+#ifdef CONFIG_SUPPORT_TERMIOS
+        .tcsetattr = NULL,
+        .tcgetattr = NULL,
+        .tcdrain = NULL,
+        .tcflush = NULL,
+#endif // CONFIG_SUPPORT_TERMIOS
+    };
+    ESP_ERROR_CHECK(esp_vfs_register(OT_EVENT_VFS_PREFIX, &vfs, NULL));
+    ESP_ERROR_CHECK(esp_vfs_register_fd_range(&vfs, NULL, OT_RESERVED_FD_MIN, OT_RESERVED_FD_MAX));
+}
+
+/**
+ * The single event fd used by the platform driver.
+ */
+static int sEventFd = -1;
+
+void platformVfsEventInit(void)
+{
+    event_register();
+    sEventFd = open(OT_EVENT_VFS_PATH, 0, 0);
+
+    assert(sEventFd != -1);
+}
+
+void platformVfsEventDeinit(void)
+{
+    if (sEventFd != -1)
+    {
+        close(sEventFd);
+        sEventFd = -1;
+    }
+}
+
+void platformVfsEventUpdate(otSysMainloopContext *aMainloop)
+{
+    FD_SET(sEventFd, &aMainloop->mReadFdSet);
+    if (sEventFd > aMainloop->mMaxFd)
+    {
+        aMainloop->mMaxFd = sEventFd;
+    }
+}
+
+void platformVfsEventProcess(otInstance *aInstance, const otSysMainloopContext *aMainloop)
+{
+    (void)aInstance;
+
+    if (FD_ISSET(sEventFd, &aMainloop->mReadFdSet))
+    {
+        // Consume the event.
+        int cnt = read(sEventFd, NULL, 0);
+
+        ESP_LOGI(OT_PLAT_LOG_TAG, "external event received, count: %d", cnt);
+    }
+}
+
+void platformVfsEventActivate(void)
+{
+    assert(sEventFd != -1);
+
+    // Write to the event fd to activate select().
+    write(sEventFd, NULL, 0);
+}

--- a/src/vfs_event.c
+++ b/src/vfs_event.c
@@ -70,9 +70,7 @@ static esp_err_t event_start_select(int                nfds,
 
     _lock_acquire_recursive(&sEvent.mLock);
 
-    VerifyOrExit(sEvent.mIsOpen && nfds > 0 && FD_ISSET(sEvent.mFd, readfds), _lock_release_recursive(&sEvent.mLock));
-
-    _lock_release_recursive(&sEvent.mLock);
+    VerifyOrExit(sEvent.mIsOpen && nfds > 0 && FD_ISSET(sEvent.mFd, readfds), OT_NOOP);
 
     sSignalSemaphore = signal_sem;
 
@@ -82,6 +80,7 @@ static esp_err_t event_start_select(int                nfds,
     }
 
 exit:
+    _lock_release_recursive(&sEvent.mLock);
     return error;
 }
 

--- a/src/vfs_event.c
+++ b/src/vfs_event.c
@@ -194,7 +194,6 @@ static void event_register(void)
 #endif // CONFIG_SUPPORT_TERMIOS
     };
     ESP_ERROR_CHECK(esp_vfs_register(OT_EVENT_VFS_PREFIX, &vfs, NULL));
-    ESP_ERROR_CHECK(esp_vfs_register_fd_range(&vfs, NULL, OT_RESERVED_FD_MIN, OT_RESERVED_FD_MAX));
 }
 
 /**
@@ -237,7 +236,7 @@ void platformVfsEventProcess(otInstance *aInstance, const otSysMainloopContext *
         // Consume the event.
         int cnt = read(sEventFd, NULL, 0);
 
-        ESP_LOGI(OT_PLAT_LOG_TAG, "external event received, count: %d", cnt);
+        ESP_LOGD(OT_PLAT_LOG_TAG, "external event received, count: %d", cnt);
     }
 }
 


### PR DESCRIPTION
This PR adds a new API `otSysMainloopBreak` to break `otSysMainloopPoll`.

An example usage:
```c
static void break_select(void *aContext)
{
    while (true)
    {
        usleep(100 * 1000);
        ESP_LOGI(CLI_LOG_TAG, "breaking the OpenThread event loop");
        otSysMainloopBreak();
    }
}

void app_main()
{
    xTaskCreate(break_select, "break_select", 5 * 1024, NULL, 4, NULL);
    xTaskCreate(run_cli, "cli", 10 * 1024, NULL, 5, NULL);
}

```